### PR TITLE
Return tibbles if that package is available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     utils
 Suggests: 
     covr,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    tibble
 Config/testthat/edition: 3
 Depends: 
     R (>= 2.10)

--- a/R/1-functions_processing.R
+++ b/R/1-functions_processing.R
@@ -48,7 +48,8 @@ import_nmr_spectra_data <- function(path, method,
   spectra_dat %>%
     bind_rows() %>%
     mutate(sampleID = gsub(".csv", "", sampleID, fixed = TRUE)) %>%
-    arrange(sampleID, ppm)
+    arrange(sampleID, ppm) %>%
+    weak_as_tibble()
 }
 
 
@@ -200,5 +201,6 @@ process_peaks <- function(path, method, pattern = "*.csv$", quiet = FALSE) {
     filter(Intensity > 0) %>%
     filter(!is.na(ppm)) %>%
     # filter(!Flags == "Weak") %>%
-    mutate(sampleID = gsub(".csv", "", sampleID, fixed = TRUE))
+    mutate(sampleID = gsub(".csv", "", sampleID, fixed = TRUE)) %>%
+    weak_as_tibble()
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,21 @@
+
+# From utils.R in https://github.com/ropensci/drake/
+# (but originally written by BBL)
+
+weak_as_tibble <- function(..., .force_df = FALSE) {
+  no_tibble <- !suppressWarnings(requireNamespace("tibble", quietly = TRUE))
+  if (.force_df || no_tibble) {
+    as.data.frame(..., stringsAsFactors = FALSE)
+  } else {
+    tibble::as_tibble(...)
+  }
+}
+
+weak_tibble <- function(..., .force_df = FALSE) {
+  no_tibble <- !suppressWarnings(requireNamespace("tibble", quietly = TRUE))
+  if (.force_df || no_tibble) {
+    data.frame(..., stringsAsFactors = FALSE)
+  } else {
+    tibble::tibble(...)
+  }
+}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,36 @@
+
+test_that("weak_as_tibble works", {
+  if(requireNamespace("tibble", quietly = TRUE)) {
+    crs <- weak_as_tibble(cars)
+    expect_s3_class(crs, "tbl")
+    crs_df <- weak_as_tibble(cars, .force_df = TRUE)
+    expect_s3_class(crs, "data.frame")
+    expect_true(!"tbl" %in% class(crs_df))
+    # tibble and data.frame versions should be equivalent
+    expect_equal(crs, crs_df, ignore_attr = TRUE)
+  } else {
+    # not much we can test without tibble!
+    crs <- weak_as_tibble(cars)
+    expect_s3_class(crs, "data.frame")
+    expect_identical(x, weak_tibble(x = 1, .force_df = TRUE))
+  }
+})
+
+
+test_that("weak_tibble works", {
+  if(requireNamespace("tibble", quietly = TRUE)) {
+    x <- weak_tibble(x = 1)
+    expect_s3_class(x, "tbl")
+    x_df <- weak_tibble(x = 1, .force_df = TRUE)
+    expect_s3_class(x_df, "data.frame")
+    expect_true(!"tbl" %in% class(x_df))
+    # tibble and data.frame versions should be equivalent
+    expect_equal(x, x_df, ignore_attr = TRUE)
+  } else {
+    # not much we can test without tibble!
+    x_df <- weak_tibble(x = 1)
+    expect_s3_class(x_df, "data.frame")
+    expect_identical(x_df, weak_tibble(x = 1, .force_df = TRUE))
+  }
+})
+


### PR DESCRIPTION
Have the import functions return a [tibble](https://tibble.tidyverse.org) if that package is available.

I have grown to strongly prefer tibbles over classic data frames; they're so much cleaner and easier to work with. This PR prioritizes — but does not require! — them.
